### PR TITLE
Rename jdbcstore resources table

### DIFF
--- a/src/community/jdbcstore/src/main/resources/org/geoserver/jdbcstore/internal/drop.h2.sql
+++ b/src/community/jdbcstore/src/main/resources/org/geoserver/jdbcstore/internal/drop.h2.sql
@@ -1,1 +1,1 @@
-DROP TABLE resource CASCADE;
+DROP TABLE resources CASCADE;

--- a/src/community/jdbcstore/src/main/resources/org/geoserver/jdbcstore/internal/drop.postgres.sql
+++ b/src/community/jdbcstore/src/main/resources/org/geoserver/jdbcstore/internal/drop.postgres.sql
@@ -1,1 +1,1 @@
-DROP TABLE resource CASCADE;
+DROP TABLE resources CASCADE;

--- a/src/community/jdbcstore/src/main/resources/org/geoserver/jdbcstore/internal/init.h2.sql
+++ b/src/community/jdbcstore/src/main/resources/org/geoserver/jdbcstore/internal/init.h2.sql
@@ -1,22 +1,22 @@
-CREATE TABLE resource
+CREATE TABLE resources
 (
   oid integer AUTO_INCREMENT NOT NULL,
   name character varying NOT NULL,
   parent integer,
   last_modified timestamp NOT NULL DEFAULT CURRENT_TIMESTAMP,
   content binary,
-  CONSTRAINT resource_pkey PRIMARY KEY (oid),
-  CONSTRAINT resource_parent_fkey FOREIGN KEY (parent)
-      REFERENCES resource (oid)
+  CONSTRAINT resources_pkey PRIMARY KEY (oid),
+  CONSTRAINT resources_parent_fkey FOREIGN KEY (parent)
+      REFERENCES resources (oid)
       ON UPDATE RESTRICT ON DELETE CASCADE,
-  CONSTRAINT resource_parent_name_key UNIQUE (parent, name),
-  CONSTRAINT resource_only_one_root_check CHECK (parent IS NOT NULL OR oid = 0)
+  CONSTRAINT resources_parent_name_key UNIQUE (parent, name),
+  CONSTRAINT resources_only_one_root_check CHECK (parent IS NOT NULL OR oid = 0)
 );
 
-CREATE INDEX resource_parent_name_idx
-  ON resource (parent NULLS FIRST, name NULLS FIRST);
+CREATE INDEX resources_parent_name_idx
+  ON resources (parent NULLS FIRST, name NULLS FIRST);
 
-INSERT INTO resource (oid, name, parent, content) VALUES (0, '', NULL, NULL);
+INSERT INTO resources (oid, name, parent, content) VALUES (0, '', NULL, NULL);
 
-ALTER TABLE resource ALTER COLUMN oid RESTART WITH 1;
+ALTER TABLE resources ALTER COLUMN oid RESTART WITH 1;
 

--- a/src/community/jdbcstore/src/main/resources/org/geoserver/jdbcstore/internal/init.postgres.sql
+++ b/src/community/jdbcstore/src/main/resources/org/geoserver/jdbcstore/internal/init.postgres.sql
@@ -1,20 +1,20 @@
-CREATE TABLE resource
+CREATE TABLE resources
 (
   oid serial NOT NULL,
   name character varying NOT NULL,
   parent integer,
   last_modified timestamp without time zone NOT NULL DEFAULT timezone('UTC'::text, now()),
   content bytea,
-  CONSTRAINT resource_pkey PRIMARY KEY (oid),
-  CONSTRAINT resource_parent_fkey FOREIGN KEY (parent)
-      REFERENCES resource (oid)
+  CONSTRAINT resources_pkey PRIMARY KEY (oid),
+  CONSTRAINT resources_parent_fkey FOREIGN KEY (parent)
+      REFERENCES resources (oid)
       ON UPDATE RESTRICT ON DELETE CASCADE,
-  CONSTRAINT resource_parent_name_key UNIQUE (parent, name),
-  CONSTRAINT resource_only_one_root_check CHECK (parent IS NOT NULL OR oid = 0)
+  CONSTRAINT resources_parent_name_key UNIQUE (parent, name),
+  CONSTRAINT resources_only_one_root_check CHECK (parent IS NOT NULL OR oid = 0)
 );
 
-CREATE INDEX resource_parent_name_idx
-  ON resource (parent NULLS FIRST, name NULLS FIRST);
+CREATE INDEX resources_parent_name_idx
+  ON resources (parent NULLS FIRST, name NULLS FIRST);
 
-INSERT INTO resource (oid, name, parent, content) VALUES (0, '', NULL, NULL);
+INSERT INTO resources (oid, name, parent, content) VALUES (0, '', NULL, NULL);
 

--- a/src/community/jdbcstore/src/test/java/org/geoserver/jdbcstore/AbstractJDBCResourceStoreTest.java
+++ b/src/community/jdbcstore/src/test/java/org/geoserver/jdbcstore/AbstractJDBCResourceStoreTest.java
@@ -66,9 +66,9 @@ public abstract class AbstractJDBCResourceStoreTest {
         @SuppressWarnings("unused")
         ResourceStore store = new JDBCResourceStore(support.getDataSource(), config);
         
-        // Check that the database has a resource table with a root record
+        // Check that the database has a resources table with a root record
         
-        ResultSet rs = support.getConnection().createStatement().executeQuery("SELECT * from resource where oid = 0");
+        ResultSet rs = support.getConnection().createStatement().executeQuery("SELECT * from resources where oid = 0");
         
         assertThat(rs.next(), describedAs("found root record",is(true)));
         assertThat(rs.getString("name"), equalTo(""));
@@ -102,7 +102,7 @@ public abstract class AbstractJDBCResourceStoreTest {
         {
             // Check that the database has a resource table with a root record
             
-            ResultSet rs = support.getConnection().createStatement().executeQuery("SELECT * from resource where oid = 0");
+            ResultSet rs = support.getConnection().createStatement().executeQuery("SELECT * from resources where oid = 0");
             
             assertThat(rs.next(), describedAs("found root record",is(true)));
             assertThat(rs.getString("name"), equalTo(""));
@@ -114,7 +114,7 @@ public abstract class AbstractJDBCResourceStoreTest {
         {
             // Check that the database has one of the child nodes
             
-            ResultSet rs = support.getConnection().createStatement().executeQuery("SELECT * from resource where parent = 0 and name='FileA'");
+            ResultSet rs = support.getConnection().createStatement().executeQuery("SELECT * from resources where parent = 0 and name='FileA'");
             
             assertThat(rs.next(), describedAs("found child FileA",is(true)));
             assertThat(rs.getString("name"), equalTo("FileA"));
@@ -136,7 +136,7 @@ public abstract class AbstractJDBCResourceStoreTest {
         {
             // Check that the database has a resource table with a root record
             
-            ResultSet rs = support.getConnection().createStatement().executeQuery("SELECT * from resource where oid = 0");
+            ResultSet rs = support.getConnection().createStatement().executeQuery("SELECT * from resources where oid = 0");
             
             assertThat(rs.next(), describedAs("found root record",is(true)));
             assertThat(rs.getString("name"), equalTo(""));

--- a/src/community/jdbcstore/src/test/java/org/geoserver/jdbcstore/AbstractJDBCResourceStoreTest.java
+++ b/src/community/jdbcstore/src/test/java/org/geoserver/jdbcstore/AbstractJDBCResourceStoreTest.java
@@ -100,7 +100,7 @@ public abstract class AbstractJDBCResourceStoreTest {
         JDBCResourceStore store = new JDBCResourceStore(support.getDataSource(), config);
         store.setLockProvider(new NullLockProvider());
         {
-            // Check that the database has a resource table with a root record
+            // Check that the database has a resources table with a root record
             
             ResultSet rs = support.getConnection().createStatement().executeQuery("SELECT * from resources where oid = 0");
             
@@ -134,7 +134,7 @@ public abstract class AbstractJDBCResourceStoreTest {
         JDBCResourceStore store = new JDBCResourceStore(support.getDataSource(), config);
         store.setLockProvider(new NullLockProvider());
         {
-            // Check that the database has a resource table with a root record
+            // Check that the database has a resources table with a root record
             
             ResultSet rs = support.getConnection().createStatement().executeQuery("SELECT * from resources where oid = 0");
             

--- a/src/community/jdbcstore/src/test/java/org/geoserver/jdbcstore/H2TestSupport.java
+++ b/src/community/jdbcstore/src/test/java/org/geoserver/jdbcstore/H2TestSupport.java
@@ -65,7 +65,7 @@ public class H2TestSupport implements DatabaseTestSupport {
     
     private PreparedStatement getInsert() throws SQLException {
         if(insert==null) {
-            insert = conn.prepareStatement("INSERT INTO resource (name, parent, content) VALUES (?, ?, ?)");
+            insert = conn.prepareStatement("INSERT INTO resources (name, parent, content) VALUES (?, ?, ?)");
         }
         return insert;
     }

--- a/src/community/jdbcstore/src/test/java/org/geoserver/jdbcstore/PostgresTestSupport.java
+++ b/src/community/jdbcstore/src/test/java/org/geoserver/jdbcstore/PostgresTestSupport.java
@@ -40,7 +40,7 @@ public class PostgresTestSupport implements DatabaseTestSupport {
         ds = createTestDataSource();
         conn = ds.getConnection();
         try {
-            insert = conn.prepareStatement("INSERT INTO resource (name, parent, content) VALUES (?, ?, ?) RETURNING oid;");
+            insert = conn.prepareStatement("INSERT INTO resources (name, parent, content) VALUES (?, ?, ?) RETURNING oid;");
         } finally {
             if(insert==null) conn.close();
         }


### PR DESCRIPTION
@NielsCharlier the renaming of the resources table was incomplete and caused the jdbcstore build to fail. There were two hardcoded instances of "resource" in main, many in test, and none of the sql was updated to match. This PR fixes these deficiencies and also renames the constant to `TABLE_RESOURCES` for consistency.
