### PR TITLE
Revert initialization change. 

### DIFF
--- a/src/community/jdbcconfig/src/main/java/org/geoserver/jdbcconfig/JDBCGeoServerLoader.java
+++ b/src/community/jdbcconfig/src/main/java/org/geoserver/jdbcconfig/JDBCGeoServerLoader.java
@@ -1,14 +1,11 @@
-/* (c) 2014 Open Source Geospatial Foundation - all rights reserved
+/* (c) 2014 - 2016 Open Source Geospatial Foundation - all rights reserved
  * (c) 2001 - 2013 OpenPlans
  * This code is licensed under the GPL 2.0 license, available at the root
  * application directory.
  */
 package org.geoserver.jdbcconfig;
 
-import java.io.IOException;
-import java.util.List;
-import java.util.logging.Logger;
-
+import com.google.common.base.Stopwatch;
 import org.geoserver.catalog.Catalog;
 import org.geoserver.catalog.CatalogFacade;
 import org.geoserver.catalog.impl.CatalogImpl;
@@ -24,9 +21,12 @@ import org.geoserver.jdbcconfig.internal.ConfigDatabase;
 import org.geoserver.jdbcconfig.internal.JDBCConfigProperties;
 import org.geoserver.platform.GeoServerExtensions;
 import org.geoserver.platform.GeoServerResourceLoader;
+import org.geoserver.platform.resource.Resource;
 import org.geotools.util.logging.Logging;
 
-import com.google.common.base.Stopwatch;
+import java.io.IOException;
+import java.util.List;
+import java.util.logging.Logger;
 
 public class JDBCGeoServerLoader extends DefaultGeoServerLoader {
 
@@ -54,10 +54,9 @@ public class JDBCGeoServerLoader extends DefaultGeoServerLoader {
         }
 
         ConfigDatabase configDatabase = ((JDBCCatalogFacade) catalogFacade).getConfigDatabase();
-
-        if (config.isInitDb()) {
-            configDatabase.initDb(config.getInitScript());
-        }
+        
+        Resource initScript = config.isInitDb() ? config.getInitScript() : null;
+        configDatabase.initDb(initScript);
 
         config.setInitDb(false);
         config.save();


### PR DESCRIPTION
Without the initDB call dbMappings doesn't get initialized, which causes failures later on.
