### PR TITLE
Remove the resourceWatcher from the applicationContext.xml

### DIFF
--- a/src/community/jdbcconfig/src/main/java/org/geoserver/jdbcloader/JDBCLoaderProperties.java
+++ b/src/community/jdbcconfig/src/main/java/org/geoserver/jdbcloader/JDBCLoaderProperties.java
@@ -1,18 +1,19 @@
+/* (c) 2016 Open Source Geospatial Foundation - all rights reserved
+ * This code is licensed under the GPL 2.0 license, available at the root
+ * application directory.
+ */
 package org.geoserver.jdbcloader;
 
+import com.google.common.base.Optional;
+import com.google.common.base.Preconditions;
+import org.geoserver.platform.resource.Resource;
+import org.geoserver.platform.resource.Resources;
+
 import java.io.IOException;
-import java.io.InputStream;
 import java.util.Collections;
 import java.util.Enumeration;
 import java.util.LinkedHashSet;
 import java.util.Properties;
-
-import org.geoserver.jdbcloader.JDBCLoaderPropertiesFactoryBean;
-import org.geoserver.platform.resource.Resource;
-import org.geoserver.platform.resource.Resources;
-
-import com.google.common.base.Optional;
-import com.google.common.base.Preconditions;
 
 public class JDBCLoaderProperties extends Properties {
     
@@ -62,7 +63,7 @@ public class JDBCLoaderProperties extends Properties {
     }
     
     public Resource getInitScript() {
-        String initScript = getProperty("initScript");
+        String initScript = fillInPlaceholders(getProperty("initScript"));
         if (initScript == null) {
             return null;
         }

--- a/src/community/jdbcstore/src/main/resources/applicationContext.xml
+++ b/src/community/jdbcstore/src/main/resources/applicationContext.xml
@@ -31,7 +31,7 @@
     <constructor-arg ref="jdbcStoreProperties" />
     <property name="cache" ref="resourceCache" />
     <property name="lockProvider" ref="lockProvider"/>
-    <property name="resourceWatcher" ref="resourceWatcher"/>
+    <!--<property name="resourceWatcher" ref="resourceWatcher"/>-->
   </bean>
 
    <bean id="resourceStore" class="org.geoserver.platform.resource.ResourceStoreProxy">

--- a/src/web/app/pom.xml
+++ b/src/web/app/pom.xml
@@ -929,6 +929,16 @@
       </dependencies>
     </profile>
     <profile>
+      <id>jdbcstore</id>
+      <dependencies>
+        <dependency>
+          <groupId>org.geoserver.community</groupId>
+          <artifactId>gs-jdbcstore</artifactId>
+          <version>${project.version}</version>
+        </dependency>
+      </dependencies>
+    </profile>
+    <profile>
       <id>script-py</id>
       <activation>
         <property><name>script</name></property>


### PR DESCRIPTION
Removed resourceWatcher. I'm not sure if it's actually needed, but it doesn't seem to be defined anywhere for me at least? 

Also added a jdbcstore profile to the web/app pom.xml, that way Start.java can be run with jdbcstore enabled.
